### PR TITLE
update harpoon to v2 and update keymaps

### DIFF
--- a/after/plugin/harpoon.lua
+++ b/after/plugin/harpoon.lua
@@ -1,11 +1,9 @@
-local mark = require("harpoon.mark")
-local ui = require("harpoon.ui")
+local harpoon = require("harpoon")
+harpoon:setup()
 
-vim.keymap.set("n", "<leader>a", mark.add_file)
-vim.keymap.set("n", "<C-e>", ui.toggle_quick_menu)
-
-vim.keymap.set("n", "<C-&>", function() ui.nav_file(1) end)
-vim.keymap.set("n", "<C-*>", function() ui.nav_file(2) end)
-vim.keymap.set("n", "<C-(>", function() ui.nav_file(3) end)
-vim.keymap.set("n", "<C-)>", function() ui.nav_file(4) end)
-
+vim.keymap.set('n', '<leader>a', function() harpoon:list():add() end)
+vim.keymap.set('n', '<C-t>', function() harpoon.ui:toggle_quick_menu(harpoon:list()) end)
+vim.keymap.set('n', '<C-q>', function() harpoon:list():select(1) end)
+vim.keymap.set('n', '<C-w>', function() harpoon:list():select(2) end)
+vim.keymap.set('n', '<C-e>', function() harpoon:list():select(3) end)
+vim.keymap.set('n', '<C-r>', function() harpoon:list():select(4) end)

--- a/after/plugin/harpoon.lua
+++ b/after/plugin/harpoon.lua
@@ -7,3 +7,15 @@ vim.keymap.set('n', '<C-q>', function() harpoon:list():select(1) end)
 vim.keymap.set('n', '<C-w>', function() harpoon:list():select(2) end)
 vim.keymap.set('n', '<C-e>', function() harpoon:list():select(3) end)
 vim.keymap.set('n', '<C-r>', function() harpoon:list():select(4) end)
+
+harpoon:extend({
+    UI_CREATE = function(cx)
+        vim.keymap.set('n', '<C-v>', function()
+            harpoon.ui:select_menu_item({ vsplit = true })
+        end, { buffer = cx.bufnr })
+
+        vim.keymap.set('n', '<C-s>', function()
+            harpoon.ui:select_menu_item({ split = true })
+        end, { buffer = cx.bufnr })
+    end,
+})

--- a/lua/home/packer.lua
+++ b/lua/home/packer.lua
@@ -19,7 +19,11 @@ return require('packer').startup(function(use)
 
   use('nvim-treesitter/nvim-treesitter', {run = ':TSUpdate'})
   use('nvim-treesitter/playground')
-  use('theprimeagen/harpoon')
+  use{
+      'ThePrimeagen/harpoon',
+      branch = 'harpoon2',
+      requires = { {'nvim-lua/plenary.nvim'} }
+  }
   use('mbbill/undotree')
   use('tpope/vim-fugitive')
   use({

--- a/lua/home/set.lua
+++ b/lua/home/set.lua
@@ -46,3 +46,9 @@ vim.opt.smartcase = true
 
 -- include dash in D movements
 vim.opt.iskeyword:append("-")
+
+-- open vsplits to right
+vim.opt.splitright = true
+
+-- open hsplits to below
+vim.opt.splitbelow = true


### PR DESCRIPTION
Harpoon's apparently had some changes!

Updated keymaps (all in normal mode)

`leader-a` to add a file
`leader-<C-{q,w,e,r}>` to open the 1st, 2nd, 3rd, 4th file in harpoon buffer
`leader-<C-t>` to pull up Harpoon ui
`leader-<C-v>` to open current highlighted row in Harpoon ui in vertical split
`leader-<C-s>` to open current highlighted row in Harpoon ui in horizontal split